### PR TITLE
[hist]: histogram summed as loop runs. tentative fix for #212

### DIFF
--- a/stats/imghist.py
+++ b/stats/imghist.py
@@ -64,9 +64,7 @@ class ImgHist():
       ylimit = (yimagesz-1) / ycubedim + 1
       zlimit = (zimagesz-1) / zcubedim + 1
 
-      hist = []
-      bins = np.zeros(self.numbins+1)  
-      count = 0
+      hist_sum = np.zeros(self.numbins, dtype=np.uint32) 
       
       # sum the histograms 
       for z in range(zlimit):
@@ -77,14 +75,9 @@ class ImgHist():
             data = db.cutout(ch, [ x*xcubedim, y*ycubedim, z*zcubedim], cubedim, self.res ).data
             
             # compute the histogram and store it 
-            hist.append(np.histogram(data[data > 0], bins=self.numbins, range=(0,self.numbins)))
+            (hist, bins) = np.histogram(data[data > 0], bins=self.numbins, range=(0,self.numbins))
+            hist_sum = np.add( hist_sum, hist )
             print "Processed cube {} {} {}".format(x,y,z)
         
-      # sum the individual histograms
-      hist_sum = np.zeros(self.numbins)
-      bins = hist[0][1] # all bins should be the same 
-      for i in range(len(hist)):
-        hist_sum += hist[i][0]
-
       return (hist_sum, bins)
       


### PR DESCRIPTION
Modifies the histogram code to sum histograms for each cube as the loop runs instead of keeping histograms for all cubes and summing at the end. All tests pass. Closes #212 .

Would be great to test on a bigger dataset. Maybe we can stand up celery on dsp063 or dsp061 and run the histogram job there closely monitored, where it's less likely to bring stuff down? ( @kunallillaney ) 
