### PR TITLE
Changes to the JSON interface to RAMON 

### DIFF
--- a/ocpca/jsonann.py
+++ b/ocpca/jsonann.py
@@ -124,6 +124,10 @@ class JSONAnnotation:
     """ return json formatted string """ 
     return json.dumps( self.annodict )
 
+  def toDictionary( self ):
+    """ return dictionary """ 
+    return self.annodict 
+
 def BasetoJSON ( anno, annotype ):
   jsonanno = JSONAnnotation( annotype, anno.annid )
 

--- a/ocpca/jsonproj.py
+++ b/ocpca/jsonproj.py
@@ -30,10 +30,17 @@ from ocpuser.models import Token
 from ocpuser.models import Channel
 from ocpuser.models import User
 
+from ocpcaerror import OCPCAError
+import logging
+logger=logging.getLogger('ocp')
 
 def autoIngest(webargs, post_data):
   """Create a project using a JSON file"""
   
+  TOKEN_CREATED = False
+  PROJECT_CREATED = False
+  CHANNEL_CREATED = False
+  DATASET_CREATED = False
   ocp_dict = json.loads(post_data)
   try:
     dataset_dict = ocp_dict['dataset']
@@ -41,19 +48,19 @@ def autoIngest(webargs, post_data):
     channels = ocp_dict['channels']
     metadata_dict = ocp_dict['metadata']
   except Exception, e:
-    print "Missing requred fields"
+    logger.error("Missing requred fields of dataset,project,channels,metadata.")
     return json.dumps("Missing required fields of dataset,project,channels,metadata. Please check if one of them is not missing.")
   
   try:
     DATASET_SCHEMA.validate(dataset_dict)
   except Exception, e:
-    print "Invalid Dataset schema"
+    logger.error("Invalid Dataset schema")
     return json.dumps("Invalid Dataset schema")
   
   try:
     PROJECT_SCHEMA.validate(project_dict)
   except Exception, e:
-    print "Invalid Project schema"
+    logger.error("Invalid Project schema")
     return json.dumps("Invalid Project schema")
     
   #try:
@@ -85,10 +92,11 @@ def autoIngest(webargs, post_data):
       if compareModelObjects(stored_ds, ds): 
         pr.dataset_id = stored_ds.dataset_name
       else:
-        print "Dataset name already exists"
+        logger.error("Dataset {} already exists and is different then the chosen dataset".format(ds.dataset_name))
         return json.dumps("Dataset {} already exists and is different then the chosen dataset. Please choose a different dataset name".format(ds.dataset_name))
     else:
       ds.save()
+      DATASET_CREATED = True
       pr.dataset_id = ds.dataset_name
 
     # Checking if the posted project already exists
@@ -104,21 +112,41 @@ def autoIngest(webargs, post_data):
           if compareModelObjects(stored_tk, tk):
             pass
           else:
-            print "Token name already exists"
+            if DATASET_CREATED:
+              ds.delete()
+            logger.error("Token {} already exists.".format(tk.token_name))
             return json.dumps("Token {} already exists. Please choose a different token name.".format(tk.token_name))
         else:
           tk.project_id = stored_pr.project_name
           tk.save()
+          TOKEN_CREATED = True
       else:
-        print "Project name already exists"
+        if DATASET_CREATED:
+          ds.delete()
+        if TOKEN_CREATED:
+          tk.delete()
+        logger.warning("Project {} already exists.".format(pr.project_name))
         return json.dumps("Project {} already exists. Please choose a different project name".format(pr.project_name))
     else:
       pr.save()
+      try:
+        pd = ocpcaproj.OCPCAProjectsDB()
+        pd.newOCPCAProject(pr.project_name)
+        PROJECT_CREATED = True
+      except Exception, e:
+        if TOKEN_CREATED():
+          tk.delete()
+        if PROJECT_CREATED:
+          pr.delete()
+        if DATASET_CREATED:
+          ds.delete()
+        logger.error("There was an error in creating the project {} database".format(pr.project_name))
+        return json.dumps("There was an error in creating the project {} database".format(pr.project_name))
       tk.project_id = pr.project_name
       tk.save()
-      pd = ocpcaproj.OCPCAProjectsDB()
-      pd.newOCPCAProject(pr.project_name)
-
+      TOKEN_CREATED = True
+    
+    channel_object_list = []
     # Iterating over channel list to store channels
     for (ch, data_url, file_format, file_type) in ch_list:
       ch.project_id = pr.project_name
@@ -126,16 +154,32 @@ def autoIngest(webargs, post_data):
       # Checking if the channel already exists or not
       if not Channel.objects.filter(channel_name = ch.channel_name, project = pr.project_name).exists():
         ch.save()
-        pd = ocpcaproj.OCPCAProjectsDB()
-        pd.newOCPCAChannel(pr.project_name, ch.channel_name)
+        # Maintain a list of channel objects created during this iteration and delete all even if one fails
+        channel_object_list.append(ch)
+        try:
+          pd = ocpcaproj.OCPCAProjectsDB()
+          pd.newOCPCAChannel(pr.project_name, ch.channel_name)
+          CHANNEL_CREATED = True
+        except Exception, e:
+          if TOKEN_CREATED:
+            tk.delete()
+          if CHANNEL_CREATED:
+            for ch_obj in channel_object_list:
+              ch_obj.delete()
+          if PROJECT_CREATED:
+            pr.delete()
+          if DATASET_CREATED:
+            ds.delete()
+          logger.error("There was an error creating in the channel {} table".format(ch.channel_name))
+          return json.dumps("There was an error in creating the channel {} table.".format(ch.channel_name))
       else:
-        print "Channel already exists"
+        logger.error("Channel {} already exists.".format(ch.channel_name))
         return json.dumps("Channel {} already exists. Please choose a different channel name.".format(ch.channel_name))
       
       from ocpca.tasks import ingest
       if data_url.endswith('/'):
         data_url = data_url[:-1]
-
+      
       # ingest(tk.token_name, ch.channel_name, ch.resolution, data_url, file_format, file_type)
       ingest.delay(tk.token_name, ch.channel_name, ch.resolution, data_url, file_format, file_type)
     
@@ -149,8 +193,9 @@ def autoIngest(webargs, post_data):
     except NameError:
       pd = ocpcaproj.OCPCAProjectsDB()
     if pr is not None:
-      pd.deleteOCPCADB(pr.project_name)
-    print "Error saving models"
+      if PROJECT_CREATED:
+        pd.deleteOCPCADB(pr.project_name)
+    logger.error("Error saving models. There was an error in the information posted")
     return json.dumps("FAILED. There was an error in the information you posted.")
 
   return json.dumps("SUCCESS. The ingest process has now started.")

--- a/ocpca/ocpcadb.py
+++ b/ocpca/ocpcadb.py
@@ -1058,6 +1058,19 @@ class OCPCADB:
   def getVoxel ( self, ch, resolution, voxel ):
     """Return the identifier at a voxel"""
     
+    # check propagate status, if not propagated then change voxel co-ordinates accordinig to base resolution
+    if ch.getPropagate() in [NOT_PROPAGATED, UNDER_PROPAGATION]:
+      chres = ch.getResolution()
+      if resolution > ch.getResolution():
+        # upsample the x and y coordinates 
+        for i in range(2):
+          voxel[i] = voxel[i] * (2**(resolution-ch.getResolution()))
+      elif resolution < ch.getResolution():
+        # downsample the x and y coordinates 
+        for i in range(2):
+          voxel[i] = voxel[i] / (2**(ch.getResolution()-resolution))
+      resolution = ch.getResolution()
+
     # get the size of the image and cube
     [xcubedim, ycubedim, zcubedim] = cubedim = self.datasetcfg.cubedim[resolution]
     [xoffset, yoffset, zoffset] = offset = self.datasetcfg.offset[resolution]

--- a/ocpca/ocpcarest.py
+++ b/ocpca/ocpcarest.py
@@ -851,8 +851,8 @@ AR_TIGHTCUTOUT = 3
 AR_BOUNDINGBOX = 4
 AR_CUBOIDS = 5
 
-def getAnnoJSONById ( ch, annoid, proj, db ):
-  """ Retrieve the annotation and return it as a serialized json string """
+def getAnnoDictById ( ch, annoid, proj, db ):
+  """ Retrieve the annotation and return it as a Python dictionary """
 
   # retrieve the annotation
   anno = db.getAnnotation ( ch, annoid ) 
@@ -860,11 +860,11 @@ def getAnnoJSONById ( ch, annoid, proj, db ):
     logger.warning("No annotation found at identifier = %s" % (annoid))
     raise OCPCAError ("No annotation found at identifier = %s" % (annoid))
 
-  # create the JSONanno obj
-  jsonanno = jsonann.AnnotationtoJSON ( anno )
+  # create the annotation obj
+  annobj = jsonann.AnnotationtoJSON ( anno )
 
   # return data
-  return jsonanno.toJSON() 
+  return annobj.toDictionary()
 
 def getAnnoById ( ch, annoid, h5f, proj, db, dataoption, resolution=None, corner=None, dim=None ): 
   """Retrieve the annotation and put it in the HDF5 file."""
@@ -1007,13 +1007,15 @@ def getAnnotation ( webargs ):
     # Check to see if this is a JSON request, and if so return the JSON objects 
     # otherwise, continue with returning the HDF5 data
     if option_args[1] == 'json':
-      jsonstr = ''
+      annobjs = {}
       try:
         db.startTxn()
         if re.match ( '^[\d,]+$', option_args[0] ): 
           annoids = map(int, option_args[0].split(','))
           for annoid in annoids: 
-            jsonstr += getAnnoJSONById ( ch, annoid, proj, db )
+            annobjs.update(getAnnoDictById ( ch, annoid, proj, db ))
+
+        jsonstr = json.dumps( annobjs )
 
       except: 
         db.rollback()

--- a/ocpca/ocpcarest.py
+++ b/ocpca/ocpcarest.py
@@ -617,23 +617,10 @@ def annId ( chanargs, proj, db ):
   [channel, service, imageargs] = chanargs.split('/',2)
   ch = ocpcaproj.OCPCAChannel(proj,channel)
   # Perform argument processing
-  (resolution, voxel) = restargs.voxel ( imageargs, proj.datasetcfg )
-  
-  # check propagate status
-  if ch.getPropagate() == NOT_PROPAGATED or ch.getPropagate() == UNDER_PROPAGATION:
-    chres = ch.getResolution()
-    if resolution > chres:
-      # upsample the x and y coordinates 
-      for i in range(2):
-        voxel[i] = voxel[i] * (2**(resolution-chres))
-    elif resolution < chres:
-      # downsample the x and y coordinates 
-      for i in range(2):
-        voxel[i] = voxel[i] / (2**(chres-resolution))
-    resolution = chres 
+  (resolution, voxel) = restargs.voxel(imageargs, proj.datasetcfg)
 
   # Get the identifier
-  return db.getVoxel ( ch, resolution, voxel )
+  return db.getVoxel(ch, resolution, voxel)
 
 def listIds ( chanargs, proj, db ):
   """Return the list of annotation identifiers in a region"""

--- a/ocpca/ocpcarest.py
+++ b/ocpca/ocpcarest.py
@@ -629,7 +629,7 @@ def annId ( chanargs, proj, db ):
     elif resolution < chres:
       # downsample the x and y coordinates 
       for i in range(2):
-        voxel[i] = voxel[i] / (2**(resolution-chres))
+        voxel[i] = voxel[i] / (2**(chres-resolution))
     resolution = chres 
 
   # Get the identifier

--- a/ocpca/ocpcarest.py
+++ b/ocpca/ocpcarest.py
@@ -618,6 +618,19 @@ def annId ( chanargs, proj, db ):
   ch = ocpcaproj.OCPCAChannel(proj,channel)
   # Perform argument processing
   (resolution, voxel) = restargs.voxel ( imageargs, proj.datasetcfg )
+  
+  # check propagate status
+  if ch.getPropagate() == NOT_PROPAGATED or ch.getPropagate() == UNDER_PROPAGATION:
+    chres = ch.getResolution()
+    if resolution > chres:
+      # upsample the x and y coordinates 
+      for i in range(2):
+        voxel[i] = voxel[i] * (2**(resolution-chres))
+    elif resolution < chres:
+      # downsample the x and y coordinates 
+      for i in range(2):
+        voxel[i] = voxel[i] / (2**(resolution-chres))
+    resolution = chres 
 
   # Get the identifier
   return db.getVoxel ( ch, resolution, voxel )

--- a/test/test_jsonann.py
+++ b/test/test_jsonann.py
@@ -85,6 +85,113 @@ class Test_Annotation_Json():
     assert( str(ann_info[str(ann_annoid)]['metadata']['status']) == str(ann_status) )
     assert( str(ann_info[str(ann_annoid)]['metadata']['confidence'])[:5] == str(ann_confidence)[:5] )
     assert( ann_info[str(ann_annoid)]['metadata']['author'] == str(ann_author) )
+  
+  def test_bigint_json(self):
+    """Test the annotation (RAMON) JSON interface with a large ID"""
+    
+    # create hdf5 file and post it
+    tmpfile = tempfile.NamedTemporaryFile()
+    h5fh = h5py.File( tmpfile.name )
+
+    ann_status = random.randint(0,4)
+    ann_confidence = random.random()
+    ann_author = 'unittest_author' 
+    ann_annoid = 10025
+    
+    # create annotation id namespace
+    idgrp = h5fh.create_group ( str(ann_annoid) )
+
+    # annotation type
+    idgrp.create_dataset ( "ANNOTATION_TYPE", (1,), np.uint32, data=1 )
+    mdgrp = idgrp.create_group( "METADATA" )
+
+    # set annotation metadata
+    mdgrp.create_dataset ( "STATUS", (1,), np.uint32, data=ann_status )
+    mdgrp.create_dataset ( "CONFIDENCE", (1,), np.float, data=ann_confidence )
+    mdgrp.create_dataset ( "AUTHOR", (1,), dtype=h5py.special_dtype(vlen=str), data=ann_author )
+
+    h5fh.flush()
+    tmpfile.seek(0)
+
+    p.annoid = putAnnotation(p, tmpfile)
+    
+    # fetching the JSON info
+    f = getURL("http://{}/ca/{}/{}/{}/json/".format(SITE_HOST, p.token, p.channels[0], ann_annoid))
+
+    # read the JSON file
+    ann_info = json.loads(f.read())
+    assert( ann_info.keys()[0] == str(ann_annoid) )
+    assert( str(ann_info[str(ann_annoid)]['metadata']['status']) == str(ann_status) )
+    assert( str(ann_info[str(ann_annoid)]['metadata']['confidence'])[:5] == str(ann_confidence)[:5] )
+    assert( ann_info[str(ann_annoid)]['metadata']['author'] == str(ann_author) )
+
+
+  def test_multiple_json(self):
+    """Test the annotation (RAMON) JSON interface with multiple objects"""
+    number_of_annotations = 3 # Note: these are 1-indexed 
+    anno_objs = {}
+
+    for i in range(number_of_annotations):
+      # create hdf5 file and post it
+      tmpfile = tempfile.NamedTemporaryFile()
+      h5fh = h5py.File( tmpfile.name )
+
+      ann_status = random.randint(0,4)
+      ann_confidence = random.random()
+      ann_author = 'unittest_author' 
+      ann_annoid = (i + 1)*10 # we multiply by 10 to avoid conflicts with above test
+    
+      anno_objs[ str(ann_annoid) ] = {
+        'ann_status': ann_status,
+        'ann_confidence': ann_confidence,
+        'ann_author': ann_author
+      }
+
+      # create annotation id namespace
+      idgrp = h5fh.create_group ( str(ann_annoid) )
+
+      # annotation type
+      idgrp.create_dataset ( "ANNOTATION_TYPE", (1,), np.uint32, data=1 )
+      mdgrp = idgrp.create_group( "METADATA" )
+
+      # set annotation metadata
+      mdgrp.create_dataset ( "STATUS", (1,), np.uint32, data=ann_status )
+      mdgrp.create_dataset ( "CONFIDENCE", (1,), np.float, data=ann_confidence )
+      mdgrp.create_dataset ( "AUTHOR", (1,), dtype=h5py.special_dtype(vlen=str), data=ann_author )
+
+      h5fh.flush()
+      tmpfile.seek(0)
+
+      p.annoid = putAnnotation(p, tmpfile)
+    
+    # fetching the JSON info
+    ann_id_str = ''
+    for i in range(number_of_annotations):
+      ann_id_str += '{}'.format( (i + 1)*10 )
+      if i < number_of_annotations - 1:
+        ann_id_str += ','
+    
+    f = getURL("http://{}/ca/{}/{}/{}/json/".format(SITE_HOST, p.token, p.channels[0], ann_id_str))
+
+    # read the JSON file
+    ann_info = json.loads(f.read())
+    
+    for i in range(number_of_annotations):
+      # make sure we have all the relevant annotation objects
+      assert( str( (i + 1)*10 ) in ann_info.keys() )
+      chosen_id = (i + 1)*10
+      chosen_obj = anno_objs[str( chosen_id )]
+      assert( str(ann_info[str(chosen_id)]['metadata']['status']) == str(chosen_obj['ann_status']) )
+      assert( str(ann_info[str(chosen_id)]['metadata']['confidence'])[:5] == str(chosen_obj['ann_confidence'])[:5] )
+      assert( ann_info[str(chosen_id)]['metadata']['author'] == str(chosen_obj['ann_author']) )
+
+    # pick an annotation object at random and check its properties 
+    chosen_id = random.randint(1,number_of_annotations)*10 
+    chosen_obj = anno_objs[str(chosen_id)]
+    assert( str(ann_info[str(chosen_id)]['metadata']['status']) == str(chosen_obj['ann_status']) )
+    assert( str(ann_info[str(chosen_id)]['metadata']['confidence'])[:5] == str(chosen_obj['ann_confidence'])[:5] )
+    assert( ann_info[str(chosen_id)]['metadata']['author'] == str(chosen_obj['ann_author']) )
+  
 
   def test_error_json(self):
     """ Request an annotation Id that doesn't exist """


### PR DESCRIPTION
Now supports multiple RAMON objects correctly. Tests added for the same.  

@randalburns: A nice post MICRONS deploy project (after all the RAMON databases are migrated and we are sure the new backend schema is working) would be to rewrite some of the frontend URLs for getting RAMON objects for clarity and to support the kv query, etc. @jovo: This is a good example of where URL versioning would be handy. 