### PR TITLE
[ramon]: not_propagated and under_propagation not included in ocpcadb

### DIFF
--- a/ocpca/ocpcadb.py
+++ b/ocpca/ocpcadb.py
@@ -33,7 +33,7 @@ from cube import Cube
 import imagecube
 import anncube
 import ocplib
-from ocptype import ANNOTATION_CHANNELS, EXCEPTION_TRUE, PROPAGATED
+from ocptype import ANNOTATION_CHANNELS, EXCEPTION_TRUE, PROPAGATED, NOT_PROPAGATED, UNDER_PROPAGATION
 
 from ocpcaerror import OCPCAError
 import logging


### PR DESCRIPTION
Was not caught by tests. Made a separate issue (#240).