### PR TITLE
Serve static routes during development

### DIFF
--- a/django/ND/urls.py
+++ b/django/ND/urls.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from django.conf.urls import patterns, include, url
+from django.conf import settings
+from django.conf.urls.static import static
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -38,4 +40,4 @@ urlpatterns = patterns('',
     url('^', include(base_urlpatterns)), # maintains unprefixed URLs
     url('^nd/', include(base_urlpatterns)),
     url('^ocp/', include(base_urlpatterns)),
-)
+) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
If there is no nginx to serve the static routes, they should be served by the django application.