### PR TITLE
Fix for RAMON Annotation Synapse KV Pairs Read Issue

### DIFF
--- a/ramon/annotation.py
+++ b/ramon/annotation.py
@@ -225,7 +225,7 @@ class AnnSynapse (Annotation):
         if type(v) == list:
           self.segments = [int(s) for s in v]
         else:
-          self.segments = [int(v)]
+          self.segments = [int(s) for s in v.replace('[','').replace(']','').split() if s.isdigit()] 
       elif k == 'syn_presegments':
         if type(v) == list:
           self.presegments = [int(s) for s in v]


### PR DESCRIPTION
v from kvpairs is a list that has been 'stringified', this converts it to a list integers.