### PR TITLE
[ingest]: getProjDB argument

### DIFF
--- a/webservices/ndwsprojingest.py
+++ b/webservices/ndwsprojingest.py
@@ -260,12 +260,12 @@ def createChannel(webargs, post_data):
       ch.save()
       
       # Create channel database using the ndproj interface
-      pd = ndproj.NDProjectsDB.getProjDB(pr.project_name)
+      pd = ndproj.NDProjectsDB.getProjDB(tk.token_name)
       pd.newNDChannel(ch.channel_name)
   except Exception, e:
-    logger.error("Error saving models")
+    logger.error("Error creating new channel: {}".format(ch.channel_name))
     # return the bad request with failed message
-    return HttpResponseBadRequest("Error saving models.", content_type="text/plain")
+    return HttpResponseBadRequest("Error creating new channel: {}".format(ch.channel_name), content_type="text/plain")
 
   # return the JSON file with success
   return HttpResponse("Success. The channels were created.", content_type="text/plain")


### PR DESCRIPTION
Looks like getProjDB expects the token for a project, not the project name...

(from ndproj/ndproject.py) 
```
class NDProject:

  def __init__(self, token_name ) : 
```

In webservices/ndwsingest.py, there are a few instances where the getProjDB method is called...

```
  def getProjDB(project_name):
    """Return a the kvengine object"""
    
    pr = NDProject(project_name)
```

There's a bit of obfuscation, but I believe the project object always operates on token, not project name. 

@kunallillaney can you confirm? If so, let's merge this, fix the rest of the issues in web services, and write a test that uses a project with a non-matching token (which is where this issue came up). 

@Aeusman I think you wrote the ndwsingest code, right? Wanna take a look and confirm I didn't mess any of your stuff up? 

Thanks! 
